### PR TITLE
Fix PyAV frame rate handling in video writer

### DIFF
--- a/inference_utils.py
+++ b/inference_utils.py
@@ -2,6 +2,7 @@ import av
 import os
 import pims
 import numpy as np
+from fractions import Fraction
 from torch.utils.data import Dataset
 from torchvision.transforms.functional import to_pil_image
 from PIL import Image
@@ -31,7 +32,7 @@ class VideoReader(Dataset):
 class VideoWriter:
     def __init__(self, path, frame_rate, bit_rate=1000000):
         self.container = av.open(path, mode='w')
-        self.stream = self.container.add_stream('h264', rate=f'{frame_rate:.4f}')
+        self.stream = self.container.add_stream('h264', rate=Fraction(frame_rate).limit_denominator())
         self.stream.pix_fmt = 'yuv420p'
         self.stream.bit_rate = bit_rate
     


### PR DESCRIPTION
## Summary
- pass a rational frame rate to PyAV when creating H.264 output streams
- avoid the `AttributeError` raised by newer PyAV versions when `rate` is passed as a formatted string

## Verification
- ran `python inference.py --variant mobilenetv3 --checkpoint rvm_mobilenetv3.pth --device cuda --input-source input.mp4 --output-type video --output-composition composition.mp4 --output-alpha alpha.mp4 --output-foreground foreground.mp4`
- ran `python inference.py --variant resnet50 --checkpoint rvm_resnet50.pth --device cuda --input-source input.mp4 --output-type video --output-composition composition.mp4 --output-alpha alpha.mp4 --output-foreground foreground.mp4`
- confirmed output metadata matches the input video and sampled frame statistics show non-degenerate alpha, foreground, and composition outputs

## Artifacts
- Conversation: https://app.warp.dev/conversation/798a5372-c0c4-46c7-a2eb-deba11e3a235

Co-Authored-By: Oz <oz-agent@warp.dev>